### PR TITLE
Add Docker Compose app service, pin UI deps, fix security config, and improve README (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,61 +1,35 @@
-spring-boot/HELP.md
-spring-boot/.gradle
-spring-boot/build/
-spring-boot/!gradle/wrapper/gradle-wrapper.jar
-spring-boot/!**/src/main/**/build/
-spring-boot/!**/src/test/**/build/
-spring-boot/### STS ###
-spring-boot/.apt_generated
-spring-boot/.classpath
-spring-boot/.factorypath
-spring-boot/.project
-spring-boot/.settings
-spring-boot/.springBeans
-spring-boot/.sts4-cache
-spring-boot/bin/
-spring-boot/!**/src/main/**/bin/
-spring-boot/!**/src/test/**/bin/
+# Gradle
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
 
-spring-boot/### IntelliJ IDEA ###
-spring-boot/.idea
-spring-boot/*.iws
-spring-boot/*.iml
-spring-boot/*.ipr
-spring-boot/out/
-spring-boot/!**/src/main/**/out/
-spring-boot/!**/src/test/**/out/
+# IDE
+.idea/
+*.iws
+*.iml
+*.ipr
+.vscode/
+!.vscode/extensions.json
 
-spring-boot/### NetBeans ###
-spring-boot/nbproject/private/
-spring-boot/nbbuild/
-spring-boot/dist/
-spring-boot/nbdist/
-spring-boot/.nb-gradle/
+# Spring Boot
+HELP.md
 
-spring-boot/### VS Code ###
-spring-boot/.vscode/
-spring-boot/k8s/secret.yaml
-spring-boot/.env
+# Secrets
+.env
+k8s/secret.yaml
 
-
-# Logs
-frontend/logs
+# Frontend
+frontend/node_modules/
+frontend/dist/
+frontend/dist-ssr/
+frontend/*.local
+frontend/logs/
 frontend/*.log
 frontend/npm-debug.log*
 frontend/yarn-debug.log*
 frontend/yarn-error.log*
 frontend/pnpm-debug.log*
 frontend/lerna-debug.log*
-
-frontend/node_modules
-frontend/dist
-frontend/dist-ssr
-frontend/*.local
-
-frontend/# Editor directories and files
-frontend/.vscode/*
-frontend/!.vscode/extensions.json
-frontend/.idea
 frontend/.DS_Store
 frontend/*.suo
 frontend/*.ntvs*

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ POST /api/v1/auth/login        Login and receive a JWT token
 
 ### Employees
 ```
-GET  /employees                Get all employees
-GET  /employees/oldest         Get the oldest employee
-GET  /employees/{projectId}    Get employees by project
+GET  /api/v1/employees                Get all employees
+GET  /api/v1/employees/oldest         Get the oldest employee
+GET  /api/v1/employees/{projectId}    Get employees by project
 ```
 
 ### Projects

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ npm install
 npm run dev
 ```
 
+### Running with Docker Compose
+
+To run the full stack (API + database) as Docker containers:
+
+```bash
+docker-compose up app
+```
+
+The API will be available at `http://localhost:8086`.
+
 ### Running SonarQube analysis locally
 
 ```bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,20 @@ services:
       - sonar_db:/var/lib/postgresql
       - sonar_db_data:/var/lib/postgresql/data
 
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8086:8086"
+    environment:
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      HOST: mysql
+      JWT_KEY: ${JWT_KEY}
+    depends_on:
+      - mysql
+
   mysql:
     image: mysql
     ports:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,18 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.21.0",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react": "^4.3.4",
-    "eslint": "^9.21.0",
-    "eslint-plugin-react-hooks": "^5.1.0",
-    "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^15.15.0",
-    "vite": "^6.2.0"
+    "@eslint/js": "9.21.0",
+    "@types/react": "19.0.10",
+    "@types/react-dom": "19.0.4",
+    "@vitejs/plugin-react": "4.3.4",
+    "eslint": "9.21.0",
+    "eslint-plugin-react-hooks": "5.1.0",
+    "eslint-plugin-react-refresh": "0.4.19",
+    "globals": "15.15.0",
+    "vite": "6.2.0"
   }
 }

--- a/src/main/java/com/ko/k8sspringboot/config/SecurityConfig.java
+++ b/src/main/java/com/ko/k8sspringboot/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 try {
                     httpSecurityCsrfConfigurer.disable()
                             .authorizeHttpRequests(r -> r
-                                    .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**")
+                                    .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**")
                                     .permitAll()
                                     .anyRequest()
                                     .authenticated())


### PR DESCRIPTION
## Summary
- Add Spring Boot app service to Docker Compose for full stack local setup
- Add Docker Compose full stack setup instructions to README
- Pin frontend dependency versions to prevent supply chain attacks
- Fix .gitignore to reflect project restructure
- Fix security config to permit `/api/v1/auth/**` endpoints
- Rename `/employees/oldtest` endpoint to `/employees/oldest`
- Update README: add domain, API, CI/CD, deployment sections, convert HTML to Markdown
- Rewrite `aws_cdk/README.md` with architecture and usage sections