### PR TITLE
Add unit tests for EmployeeServiceImpl and update documentation (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,26 @@ GET  /projects/{id}                                     Get project by ID
 POST /projects/{projectId}/employees/{employeeId}       Add employee to project
 ```
 
+## Testing
+
+### Unit Tests
+
+Unit tests are written using JUnit 5 and Mockito. Dependencies are mocked to isolate
+the logic of the class under test.
+
+Current test coverage:
+
+- `EmployeeServiceImpl` — `getEmployees()`
+
+Run tests locally:
+
+```bash
+./gradlew test
+```
+
+Coverage reports are generated with JaCoCo after each test run and available at:
+`build/reports/jacoco/test/html/index.html`
+
 ## CI/CD
 
 GitHub Actions pipelines are configured for two branches:

--- a/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
+++ b/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
@@ -60,4 +60,28 @@ class EmployeeServiceImplTest {
         assertEquals(dto, result.get(0));
         verify(modelMapper, times(1)).map(entity, EmployeeDto.class);
     }
+
+    @Test
+    void getEmployees_callsMapOncePerEntity_whenMultipleEmployeesExist() {
+        EmployeeEntity entity1 = EmployeeEntity.builder()
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+        EmployeeEntity entity2 = EmployeeEntity.builder()
+                .age(25).firstName("Jane").lastName("Smith")
+                .salary(BigDecimal.valueOf(60000)).build();
+
+        EmployeeDto dto1 = EmployeeDto.builder().age(30).firstName("John").build();
+        EmployeeDto dto2 = EmployeeDto.builder().age(25).firstName("Jane").build();
+
+        when(employeeRepository.findAll()).thenReturn(List.of(entity1, entity2));
+        when(modelMapper.map(entity1, EmployeeDto.class)).thenReturn(dto1);
+        when(modelMapper.map(entity2, EmployeeDto.class)).thenReturn(dto2);
+
+        List<EmployeeDto> result = employeeService.getEmployees();
+
+        assertEquals(2, result.size());
+        verify(modelMapper, times(1)).map(entity1, EmployeeDto.class);
+        verify(modelMapper, times(1)).map(entity2, EmployeeDto.class);
+        verifyNoMoreInteractions(modelMapper);
+    }
 }

--- a/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
+++ b/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.ko.k8sspringboot;
 
+import com.ko.k8sspringboot.models.dto.EmployeeDto;
 import com.ko.k8sspringboot.repository.EmployeeRepository;
 import com.ko.k8sspringboot.service.impl.EmployeeServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -8,6 +9,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class EmployeeServiceImplTest {
@@ -22,6 +28,13 @@ class EmployeeServiceImplTest {
     private EmployeeServiceImpl employeeService;
 
     @Test
-    void getAllEmployeesByProject_returnsEmptyList() {
+    void getEmployees_returnsEmptyList_whenNoEmployeesExist() {
+        when(employeeRepository.findAll()).thenReturn(List.of());
+
+        List<EmployeeDto> result = employeeService.getEmployees();
+
+        assertTrue(result.isEmpty());
+        verify(employeeRepository, times(1)).findAll();
+        verifyNoInteractions(modelMapper);
     }
 }

--- a/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
+++ b/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.ko.k8sspringboot;
 
 import com.ko.k8sspringboot.models.dto.EmployeeDto;
+import com.ko.k8sspringboot.models.entity.EmployeeEntity;
 import com.ko.k8sspringboot.repository.EmployeeRepository;
 import com.ko.k8sspringboot.service.impl.EmployeeServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -10,8 +11,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
+import java.math.BigDecimal;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -36,5 +39,25 @@ class EmployeeServiceImplTest {
         assertTrue(result.isEmpty());
         verify(employeeRepository, times(1)).findAll();
         verifyNoInteractions(modelMapper);
+    }
+
+    @Test
+    void getEmployees_returnsMappedDtos_whenEmployeesExist() {
+        EmployeeEntity entity = EmployeeEntity.builder()
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        EmployeeDto dto = EmployeeDto.builder()
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        when(employeeRepository.findAll()).thenReturn(List.of(entity));
+        when(modelMapper.map(entity, EmployeeDto.class)).thenReturn(dto);
+
+        List<EmployeeDto> result = employeeService.getEmployees();
+
+        assertEquals(1, result.size());
+        assertEquals(dto, result.get(0));
+        verify(modelMapper, times(1)).map(entity, EmployeeDto.class);
     }
 }


### PR DESCRIPTION
## Summary
- Add unit tests for `EmployeeServiceImpl.getEmployees()` using JUnit 5 and Mockito
  - Empty list case
  - Single employee mapped to DTO
  - Multiple employees — verify map called once per entity
- Add Testing section to README with coverage report instructions