### PR TITLE
Add unit tests for create() and update testing documentation (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ the logic of the class under test.
 
 Current test coverage:
 
-- `EmployeeServiceImpl` — `getEmployees()`, `create()`
+- `EmployeeServiceImpl`
+  - `getEmployees()` — empty list, employees exist, map called once per entity
+  - `create()` — returns mapped DTO of saved entity
 
 Run tests locally:
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ the logic of the class under test.
 
 Current test coverage:
 
-- `EmployeeServiceImpl` — `getEmployees()`
+- `EmployeeServiceImpl` — `getEmployees()`, `create()`
 
 Run tests locally:
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Current test coverage:
 
 - `EmployeeServiceImpl`
   - `getEmployees()` — empty list, employees exist, map called once per entity
-  - `create()` — returns mapped DTO of saved entity
+  - `create()` — returns mapped DTO of saved entity, modelMapper called correctly (DTO→Entity, saved Entity→DTO)
 
 Run tests locally:
 

--- a/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
+++ b/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
@@ -114,4 +114,33 @@ class EmployeeServiceImplTest {
 
         assertEquals(expectedDto, result);
     }
+
+    @Test
+    void create_callsModelMapperTwice_withCorrectArguments() {
+        EmployeeDto inputDto = EmployeeDto.builder()
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        EmployeeEntity mappedEntity = EmployeeEntity.builder()
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        EmployeeEntity savedEntity = EmployeeEntity.builder()
+                .id(UUID.randomUUID())
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        EmployeeDto expectedDto = EmployeeDto.builder()
+                .id(savedEntity.getId()).build();
+
+        when(modelMapper.map(inputDto, EmployeeEntity.class)).thenReturn(mappedEntity);
+        when(employeeRepository.save(mappedEntity)).thenReturn(savedEntity);
+        when(modelMapper.map(savedEntity, EmployeeDto.class)).thenReturn(expectedDto);
+
+        employeeService.create(inputDto);
+
+        verify(modelMapper, times(1)).map(inputDto, EmployeeEntity.class);
+        verify(modelMapper, times(1)).map(savedEntity, EmployeeDto.class);
+        verifyNoMoreInteractions(modelMapper);
+    }
 }

--- a/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
+++ b/src/test/java/com/ko/k8sspringboot/EmployeeServiceImplTest.java
@@ -2,6 +2,7 @@ package com.ko.k8sspringboot;
 
 import com.ko.k8sspringboot.models.dto.EmployeeDto;
 import com.ko.k8sspringboot.models.entity.EmployeeEntity;
+import java.util.UUID;
 import com.ko.k8sspringboot.repository.EmployeeRepository;
 import com.ko.k8sspringboot.service.impl.EmployeeServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -83,5 +84,34 @@ class EmployeeServiceImplTest {
         verify(modelMapper, times(1)).map(entity1, EmployeeDto.class);
         verify(modelMapper, times(1)).map(entity2, EmployeeDto.class);
         verifyNoMoreInteractions(modelMapper);
+    }
+
+    @Test
+    void create_returnsMappedDto_whenEmployeeIsSaved() {
+        EmployeeDto inputDto = EmployeeDto.builder()
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        EmployeeEntity mappedEntity = EmployeeEntity.builder()
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        EmployeeEntity savedEntity = EmployeeEntity.builder()
+                .id(UUID.randomUUID())
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        EmployeeDto expectedDto = EmployeeDto.builder()
+                .id(savedEntity.getId())
+                .age(30).firstName("John").lastName("Doe")
+                .salary(BigDecimal.valueOf(50000)).build();
+
+        when(modelMapper.map(inputDto, EmployeeEntity.class)).thenReturn(mappedEntity);
+        when(employeeRepository.save(mappedEntity)).thenReturn(savedEntity);
+        when(modelMapper.map(savedEntity, EmployeeDto.class)).thenReturn(expectedDto);
+
+        EmployeeDto result = employeeService.create(inputDto);
+
+        assertEquals(expectedDto, result);
     }
 }


### PR DESCRIPTION
## Summary
- Add unit test for `create()` — returns mapped DTO of saved entity
- Add unit test for `create()` — verifies modelMapper called correctly (DTO→Entity, saved Entity→DTO)
- Update README testing section with test case details for `getEmployees()` and `create()`